### PR TITLE
Add filtering options

### DIFF
--- a/elements/options.htm
+++ b/elements/options.htm
@@ -35,6 +35,41 @@
 			<span class="exlinks-options-subtitle">Domain Settings</span>
 			<table id="exlinks-options-domains" class="exlinks-options-table">
 			</table>
+			<span class="exlinks-options-subtitle">Filter Settings</span>
+			<div>
+				Use <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions" target="_blank" rel="noreferrer nofollow">regular expressions</a>, one per line. <span style="opacity: 0.75;">(This is very similar to 4chan-x style filtering)</span><br />
+				Lines starting with a <code>#</code> will be ignored, along with improperly formatted regular expressions.<br />
+				For example, <code>/touhou/i</code> will highlight entries containing the string `<code>touhou</code>`, case-insensitive.<br /><br />
+				You can use these settings with each regular expression, separate them with semicolons:<br />
+				<ul>
+					<li>
+						Force a gallery to not be highlighted. If omitted, the gallery will be highlighted as normal.<br />
+						For example: <code>bad:yes;</code> or <code>bad:no;</code>.
+					</li>
+					<li>
+						Only apply the selector if the category of the gallery matches one from a list.<br />
+						For example: <code>only:doujinshi,manga;</code>.
+					</li>
+					<li>
+						Only apply the selector if the category of the gallery doesn&quot;t match <strong>any</strong> from a list.<br />
+						For example: <code>not:western,non-h;</code>.
+					</li>
+					<li>
+						Apply a colored decoration to the matched text.<br />
+						For example: <code>color:red;</code>, <code>underline:#0080f0;</code>, or <code>background:rgba(0,255,0,0.5);</code>.
+					</li>
+					<li>
+						Apply a colored decoration to the [Ex] or [EH] tag.<br />
+						For example: <code>link-color:blue;</code>, <code>link-underline:#bf48b5;</code>, or <code>link-background:rgba(220,200,20,0.5);</code>.
+					</li>
+				</ul>
+				For easy <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Color_keywords" target="_blank" rel="noreferrer nofollow">HTML color</a> selection, you can use the following helper to select a color:<br />
+				<div>
+					<input type="color" value="#808080" class="exlinks-options-color-input" /><input type="text" value="#808080" class="exlinks-options-color-input" readonly="readonly" /><input type="text" value="rgba(128,128,128,1)" class="exlinks-options-color-input" readonly="readonly" />
+				</div><br />
+			</div>
+			<table id="exlinks-options-filter" class="exlinks-options-table">
+			</table>
 			<span class="exlinks-options-subtitle">Debugger Settings</span>
 			<table id="exlinks-options-debug" class="exlinks-options-table">
 			</table>

--- a/style.css
+++ b/style.css
@@ -37,11 +37,11 @@
 	border-bottom-color: #a2a2a2;
 	-webkit-border-radius: 4px;
 		-moz-border-radius: 4px;
-			  border-radius: 4px;
+				border-radius: 4px;
 	*zoom: 1;
 	-webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
 		-moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
-			  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+				box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .noise {
@@ -209,10 +209,13 @@ a.exsauce-disabled {
 	margin: 0 4px;
 }
 
-.extag {
+.extag-block {
 	display: inline-block !important;
-	text-decoration: none !important;
 	margin: 0px 2px !important;
+}
+.extag {
+	text-decoration: none !important;
+	position: relative;
 }
 
 .exdetails {
@@ -272,8 +275,8 @@ a.exsauce-disabled {
 	margin-left: -1px;
 	margin-right: -1px;
 	margin-bottom: -2px;
-   background-repeat: no-repeat;
-   background-size: cover;
+	 background-repeat: no-repeat;
+	 background-size: cover;
 	position: relative;
 }
 
@@ -296,12 +299,12 @@ a.exsauce-disabled {
 
 .exthumbnail {
 	float: left;
-	background-image: url(#{data.thumb}); 
+	background-image: url(#{data.thumb});
 	margin-right: 8px;
-	width: 140px; 
-	height: 200px; 
-	background-repeat: no-repeat; 
-	background-size: cover; 
+	width: 140px;
+	height: 200px;
+	background-repeat: no-repeat;
+	background-size: cover;
 	background-position: 25% 0%;
 }
 
@@ -334,9 +337,9 @@ a.exsauce-disabled {
 
 .exlinks-options-button {
 	margin: 4px 2px;
-	display: inline-block !important; 
-	padding: 4px; 
-	background: rgba(0,0,0,0.05); 
+	display: inline-block !important;
+	padding: 4px;
+	background: rgba(0,0,0,0.05);
 	border-radius: 3px;
 }
 
@@ -348,7 +351,7 @@ a.exsauce-disabled {
 .exlinks-options-version {
 	margin: 0 4px;
 	opacity: 0.9;
-	vertical-align: 75%; 
+	vertical-align: 75%;
 	text-decoration: none !important;
 }
 
@@ -368,13 +371,13 @@ a.exsauce-disabled {
 
 .exlinks-options-notice {
 	float: right;
-	padding-top: 7px; 
+	padding-top: 7px;
 	margin-right: 4px;
 	opacity: 0.6;
 }
 
 .exlinks-options-table {
-	width: 100%; 
+	width: 100%;
 	border: 1px solid rgba(0,0,0,0.2);
 	border-radius: 4px;
 	margin: 4px 0;
@@ -382,3 +385,43 @@ a.exsauce-disabled {
 
 .exlinks-options-table tr:nth-child(even) { background-color: rgba(0,0,0,0.05); }
 .exlinks-options-table tr:nth-child(odd) { background-color: rgba(0,0,0,0.025); }
+
+#exlinks-options ul {
+	padding: 0;
+}
+#exlinks-options ul>li {
+	margin: 0.75em 2em;
+	list-style: outside none disc;
+}
+#exlinks-options code {
+	color: #000;
+	background-color: #fff;
+}
+
+.exlinks-options-color-input {
+	padding: 0.25em;
+	margin: 0 1em 0 0;
+	display: inline-block;
+	vertical-align: middle;
+	line-height: 1.5em;
+	height: 2em;
+	width: 8em;
+	box-sizing: border-box;
+	-moz-box-sizing: border-box;
+}
+.exlinks-options-color-input:last-of-type {
+	width: 11em;
+}
+
+.extag.exfilter-good,
+.exbutton.exfilter-good,
+.exgallery.exfilter-good,
+.exuploader.exfilter-good {
+	font-weight: bold;
+}
+
+.exfilter-text {
+	display: inline;
+}
+.exfilter-text-inner {
+}


### PR DESCRIPTION
I was going to go and fork ExLinks to have some basic tag flagging when I realized that it was already a ["planned" feature](https://github.com/Hupotronic/ExLinks/issues/13) ([apparently since the first commit](https://github.com/Hupotronic/ExLinks/commit/cab9761773e2a3eae9f1791f047fc699b44d8534#diff-dc51be72a07d43442f25f87c616fb7b4R47).)

So I've added in some filtering rules which seem to pretty closely match the initial commit's idea / 4chan-x style filtering. It might be a bit long, but see if you think it should be committed to the main repo.

[Image 1](https://cloud.githubusercontent.com/assets/10576365/9422199/be725858-4858-11e5-9033-7cee46e97656.png) - example of some highlighting rules being applied
[Image 2](https://cloud.githubusercontent.com/assets/10576365/9422201/c7c4e10a-4858-11e5-945e-9e1f95e8d76b.png) - what most of the new settings looks like

[Demo build](https://gist.github.com/dnsev-h/ac27597ee39640cc5316) if necessary